### PR TITLE
Add booking cancel/accept API flows with bloc state handling

### DIFF
--- a/futsal_app/lib/core/service/api_const.dart
+++ b/futsal_app/lib/core/service/api_const.dart
@@ -25,6 +25,11 @@ class ApiConst {
 
   // bookings
   static const String bookings = 'Booking';
+  static String cancelBooking(int id) => 'Booking/cancel/$id';
+  static String acceptBooking(int id) => 'Booking/accept/$id';
+  static const String pendingBookings = 'Booking/pending';
+  static const String completedBookings = 'Booking/completed';
+  static const String cancelledBookings = 'Booking/cancelled';
 
   //reviews
   static const String reviews = 'Reviews'; //get and post reviews

--- a/futsal_app/lib/view/bookings/bloc/bookings_bloc.dart
+++ b/futsal_app/lib/view/bookings/bloc/bookings_bloc.dart
@@ -1,0 +1,133 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:ui/view/bookings/data/model/booking.dart';
+import 'package:ui/view/bookings/data/repository/booking_repository.dart';
+
+part 'bookings_event.dart';
+part 'bookings_state.dart';
+
+class BookingsBloc extends Bloc<BookingsEvent, BookingsState> {
+  final BookingRepository _bookingRepository;
+
+  BookingsBloc({required BookingRepository bookingRepository})
+    : _bookingRepository = bookingRepository,
+      super(const BookingsState()) {
+    on<LoadBookings>(_onLoadBookings);
+    on<CancelBookingRequested>(_onCancelBookingRequested);
+    on<AcceptBookingRequested>(_onAcceptBookingRequested);
+  }
+
+  Future<void> _onLoadBookings(
+    LoadBookings event,
+    Emitter<BookingsState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        isLoading: true,
+        clearErrorMessage: true,
+        clearInfoMessage: true,
+        lastActionType: BookingActionType.none,
+        clearActionBooking: true,
+      ),
+    );
+
+    try {
+      final bookings = await _bookingRepository.getBookings();
+      emit(
+        state.copyWith(
+          bookings: bookings,
+          isLoading: false,
+          clearErrorMessage: true,
+          clearInfoMessage: true,
+          clearProcessingBookingId: true,
+          lastActionType: BookingActionType.none,
+          clearActionBooking: true,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          isLoading: false,
+          errorMessage: e.toString().replaceFirst('Exception: ', ''),
+          clearProcessingBookingId: true,
+          lastActionType: BookingActionType.none,
+          clearActionBooking: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onCancelBookingRequested(
+    CancelBookingRequested event,
+    Emitter<BookingsState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        processingBookingId: event.booking.id,
+        clearErrorMessage: true,
+        clearInfoMessage: true,
+      ),
+    );
+
+    try {
+      await _bookingRepository.cancelBooking(event.booking.id);
+      final refreshedBookings = await _bookingRepository.getBookings();
+
+      emit(
+        state.copyWith(
+          bookings: refreshedBookings,
+          clearProcessingBookingId: true,
+          infoMessage: 'Booking cancelled successfully.',
+          lastActionType: BookingActionType.cancelled,
+          actionBooking: event.booking,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          clearProcessingBookingId: true,
+          errorMessage: e.toString().replaceFirst('Exception: ', ''),
+          lastActionType: BookingActionType.none,
+          clearActionBooking: true,
+        ),
+      );
+    }
+  }
+
+  Future<void> _onAcceptBookingRequested(
+    AcceptBookingRequested event,
+    Emitter<BookingsState> emit,
+  ) async {
+    emit(
+      state.copyWith(
+        processingBookingId: event.booking.id,
+        clearErrorMessage: true,
+        clearInfoMessage: true,
+      ),
+    );
+
+    try {
+      await _bookingRepository.acceptBooking(event.booking.id);
+      final refreshedBookings = await _bookingRepository.getBookings();
+
+      emit(
+        state.copyWith(
+          bookings: refreshedBookings,
+          clearProcessingBookingId: true,
+          infoMessage: 'Booking accepted successfully.',
+          lastActionType: BookingActionType.accepted,
+          actionBooking: event.booking,
+        ),
+      );
+    } catch (e) {
+      emit(
+        state.copyWith(
+          clearProcessingBookingId: true,
+          errorMessage: e.toString().replaceFirst('Exception: ', ''),
+          lastActionType: BookingActionType.none,
+          clearActionBooking: true,
+        ),
+      );
+    }
+  }
+}

--- a/futsal_app/lib/view/bookings/bloc/bookings_event.dart
+++ b/futsal_app/lib/view/bookings/bloc/bookings_event.dart
@@ -1,0 +1,30 @@
+part of 'bookings_bloc.dart';
+
+abstract class BookingsEvent extends Equatable {
+  const BookingsEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class LoadBookings extends BookingsEvent {
+  const LoadBookings();
+}
+
+class CancelBookingRequested extends BookingsEvent {
+  final Booking booking;
+
+  const CancelBookingRequested(this.booking);
+
+  @override
+  List<Object?> get props => [booking.id];
+}
+
+class AcceptBookingRequested extends BookingsEvent {
+  final Booking booking;
+
+  const AcceptBookingRequested(this.booking);
+
+  @override
+  List<Object?> get props => [booking.id];
+}

--- a/futsal_app/lib/view/bookings/bloc/bookings_state.dart
+++ b/futsal_app/lib/view/bookings/bloc/bookings_state.dart
@@ -1,0 +1,61 @@
+part of 'bookings_bloc.dart';
+
+enum BookingActionType { none, cancelled, accepted }
+
+class BookingsState extends Equatable {
+  final List<Booking> bookings;
+  final bool isLoading;
+  final int? processingBookingId;
+  final String? errorMessage;
+  final String? infoMessage;
+  final BookingActionType lastActionType;
+  final Booking? actionBooking;
+
+  const BookingsState({
+    this.bookings = const [],
+    this.isLoading = false,
+    this.processingBookingId,
+    this.errorMessage,
+    this.infoMessage,
+    this.lastActionType = BookingActionType.none,
+    this.actionBooking,
+  });
+
+  BookingsState copyWith({
+    List<Booking>? bookings,
+    bool? isLoading,
+    int? processingBookingId,
+    bool clearProcessingBookingId = false,
+    String? errorMessage,
+    bool clearErrorMessage = false,
+    String? infoMessage,
+    bool clearInfoMessage = false,
+    BookingActionType? lastActionType,
+    Booking? actionBooking,
+    bool clearActionBooking = false,
+  }) {
+    return BookingsState(
+      bookings: bookings ?? this.bookings,
+      isLoading: isLoading ?? this.isLoading,
+      processingBookingId: clearProcessingBookingId
+          ? null
+          : (processingBookingId ?? this.processingBookingId),
+      errorMessage: clearErrorMessage ? null : (errorMessage ?? this.errorMessage),
+      infoMessage: clearInfoMessage ? null : (infoMessage ?? this.infoMessage),
+      lastActionType: lastActionType ?? this.lastActionType,
+      actionBooking: clearActionBooking ? null : (actionBooking ?? this.actionBooking),
+    );
+  }
+
+  @override
+  List<Object?> get props => [
+    bookings,
+    isLoading,
+    processingBookingId,
+    errorMessage,
+    infoMessage,
+    lastActionType,
+    actionBooking?.id,
+    actionBooking?.status,
+  ];
+}

--- a/futsal_app/lib/view/bookings/bookings.dart
+++ b/futsal_app/lib/view/bookings/bookings.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:ui/core/simple_theme.dart';
 import '../../core/dimension.dart';
 import '../../core/service/notification_service.dart';
+import 'bloc/bookings_bloc.dart';
 import 'data/repository/booking_repository.dart';
 import 'data/model/booking.dart';
 import 'widgets/review_dialog.dart';
@@ -18,105 +19,127 @@ class BookingsScreen extends StatefulWidget {
 
 class _BookingsScreenState extends State<BookingsScreen>
     with SingleTickerProviderStateMixin {
-  final _repo = BookingRepository();
-  late Future<List<Booking>> _future;
   late final TabController _tabController;
 
   @override
   void initState() {
     super.initState();
     _tabController = TabController(length: 3, vsync: this);
-    _future = _repo.getBookings();
-  }
-
-  Future<void> _refresh() async {
-    setState(() {
-      _future = _repo.getBookings();
-    });
-    await _future;
   }
 
   @override
   Widget build(BuildContext context) {
     Dimension.init(context);
-    return Scaffold(
-      backgroundColor: Theme.of(context).scaffoldBackgroundColor,
-      appBar: PreferredSize(
-        preferredSize: Size.fromHeight(Dimension.height(70)),
-        child: Container(
-          width: double.infinity,
+    return BlocProvider(
+      create: (_) =>
+          BookingsBloc(bookingRepository: BookingRepository())
+            ..add(const LoadBookings()),
+      child: BlocListener<BookingsBloc, BookingsState>(
+        listenWhen: (previous, current) =>
+            previous.errorMessage != current.errorMessage ||
+            previous.infoMessage != current.infoMessage,
+        listener: (context, state) {
+          if (state.errorMessage != null) {
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(state.errorMessage!)),
+            );
+          }
 
-          padding: EdgeInsets.symmetric(
-            horizontal: Dimension.width(20),
-            vertical: Dimension.height(20),
-          ),
-          decoration: BoxDecoration(
-            color: Theme.of(context).colorScheme.surface,
-            border: Border(
-              bottom: BorderSide(
-                color: Theme.of(
-                  context,
-                ).colorScheme.outline.withValues(alpha: 0.1),
-                width: 1,
+          if (state.infoMessage != null) {
+            if (state.lastActionType == BookingActionType.cancelled &&
+                state.actionBooking != null) {
+              NotificationService().showBookingCancelled(
+                groundName: state.actionBooking!.groundName,
+                bookingDate: _prettyDate(state.actionBooking!.bookingDate),
+              );
+            }
+
+            ScaffoldMessenger.of(context).showSnackBar(
+              SnackBar(content: Text(state.infoMessage!)),
+            );
+          }
+        },
+        child: Scaffold(
+          backgroundColor: Theme.of(context).scaffoldBackgroundColor,
+          appBar: PreferredSize(
+            preferredSize: Size.fromHeight(Dimension.height(70)),
+            child: Container(
+              width: double.infinity,
+              padding: EdgeInsets.symmetric(
+                horizontal: Dimension.width(20),
+                vertical: Dimension.height(20),
+              ),
+              decoration: BoxDecoration(
+                color: Theme.of(context).colorScheme.surface,
+                border: Border(
+                  bottom: BorderSide(
+                    color: Theme.of(
+                      context,
+                    ).colorScheme.outline.withValues(alpha: 0.1),
+                    width: 1,
+                  ),
+                ),
+              ),
+              child: Column(
+                children: [
+                  SizedBox(height: Dimension.height(25)),
+                  Row(
+                    children: [
+                      Text(
+                        'My Bookings',
+                        style: TextStyle(
+                          fontSize: Dimension.font(20),
+                          fontWeight: FontWeight.w600,
+                          color: Theme.of(context).colorScheme.onPrimary,
+                        ),
+                      ),
+                    ],
+                  ),
+                ],
               ),
             ),
           ),
-          child: Column(
+          body: Column(
             children: [
-              SizedBox(height: Dimension.height(25)),
-              Row(
-                children: [
-                  Text(
-                    'My Bookings',
-                    style: TextStyle(
-                      fontSize: Dimension.font(20),
-                      fontWeight: FontWeight.w600,
-                      color: Theme.of(context).colorScheme.onPrimary,
-                    ),
+              Container(
+                color: Theme.of(context).colorScheme.surface,
+                child: TabBar(
+                  overlayColor: WidgetStateProperty.all(Colors.transparent),
+                  controller: _tabController,
+                  splashBorderRadius: null,
+                  splashFactory: null,
+                  indicatorSize: TabBarIndicatorSize.tab,
+                  indicatorPadding: EdgeInsets.symmetric(
+                    horizontal: Dimension.width(10),
                   ),
-                ],
+                  tabs: [
+                    Padding(
+                      padding: EdgeInsets.symmetric(
+                        vertical: Dimension.height(15),
+                      ),
+                      child: Text('Upcoming'),
+                    ),
+                    Text('Completed'),
+                    Text('Cancelled'),
+                  ],
+                ),
+              ),
+              Expanded(
+                child: Padding(
+                  padding: EdgeInsets.only(top: Dimension.height(8)),
+                  child: TabBarView(
+                    controller: _tabController,
+                    children: [
+                      _buildBookingList(0),
+                      _buildBookingList(1),
+                      _buildBookingList(2),
+                    ],
+                  ),
+                ),
               ),
             ],
           ),
         ),
-      ),
-      body: Column(
-        children: [
-          Container(
-            color: Theme.of(context).colorScheme.surface,
-            child: TabBar(
-              overlayColor: WidgetStateProperty.all(Colors.transparent),
-              controller: _tabController,
-              splashBorderRadius: null,
-              splashFactory: null,
-              indicatorSize: TabBarIndicatorSize.tab,
-              indicatorPadding: EdgeInsets.symmetric(
-                horizontal: Dimension.width(10),
-              ),
-              tabs: [
-                Padding(
-                  padding: EdgeInsets.symmetric(vertical: Dimension.height(15)),
-                  child: Text('Upcoming'),
-                ),
-                Text('Completed'),
-                Text('Cancelled'),
-              ],
-            ),
-          ),
-          Expanded(
-            child: Padding(
-              padding: EdgeInsets.only(top: Dimension.height(8)),
-              child: TabBarView(
-                controller: _tabController,
-                children: [
-                  _buildBookingList(0),
-                  _buildBookingList(1),
-                  _buildBookingList(2),
-                ],
-              ),
-            ),
-          ),
-        ],
       ),
     );
   }
@@ -128,45 +151,49 @@ class _BookingsScreenState extends State<BookingsScreen>
   }
 
   Widget _buildBookingList(int statusFilter) {
-    return FutureBuilder<List<Booking>>(
-      future: _future,
-      builder: (context, snap) {
-        if (snap.connectionState == ConnectionState.waiting) {
+    return BlocBuilder<BookingsBloc, BookingsState>(
+      builder: (context, state) {
+        if (state.isLoading && state.bookings.isEmpty) {
           return _LoadingList();
         }
-        if (snap.hasError) {
-          return _ErrorView(message: snap.error.toString(), onRetry: _refresh);
+
+        if (state.errorMessage != null && state.bookings.isEmpty) {
+          return _ErrorView(
+            message: state.errorMessage!,
+            onRetry: () => context.read<BookingsBloc>().add(const LoadBookings()),
+          );
         }
-        final data = snap.data ?? [];
+
         final now = DateTime.now();
         List<Booking> filtered;
 
         if (statusFilter == 0) {
-          // Upcoming: bookingDate is today or future AND status is 0 (pending) or 1 (confirmed)
-          filtered = data
+          filtered = state.bookings
               .where(
                 (b) =>
-                    (b.bookingDate.isAfter(now) ||
-                        _sameDay(b.bookingDate, now)) &&
+                    (b.bookingDate.isAfter(now) || _sameDay(b.bookingDate, now)) &&
                     (b.status == 0 || b.status == 1),
               )
               .toList();
         } else if (statusFilter == 1) {
-          // Completed tab: show bookings with status 3 (Completed)
-          filtered = data.where((b) => b.status == 3).toList();
+          filtered = state.bookings.where((b) => b.status == 3).toList();
         } else {
-          // Cancelled tab: show bookings with status 2 (Cancelled)
-          filtered = data.where((b) => b.status == 2).toList();
+          filtered = state.bookings.where((b) => b.status == 2).toList();
         }
 
         filtered.sort((a, b) => b.bookingDate.compareTo(a.bookingDate));
 
         if (filtered.isEmpty) {
-          return _EmptyView(statusFilter: statusFilter, onRefresh: _refresh);
+          return _EmptyView(
+            statusFilter: statusFilter,
+            onRefresh: () => context.read<BookingsBloc>().add(const LoadBookings()),
+          );
         }
 
         return RefreshIndicator(
-          onRefresh: _refresh,
+          onRefresh: () async {
+            context.read<BookingsBloc>().add(const LoadBookings());
+          },
           child: ListView.separated(
             padding: EdgeInsets.fromLTRB(
               Dimension.width(16),
@@ -177,9 +204,14 @@ class _BookingsScreenState extends State<BookingsScreen>
             itemCount: filtered.length,
             separatorBuilder: (_, __) => SizedBox(height: Dimension.height(12)),
             itemBuilder: (context, i) {
+              final booking = filtered[i];
               return _BookingCard(
-                booking: filtered[i],
+                booking: booking,
                 isUpcoming: statusFilter == 0,
+                isProcessing: state.processingBookingId == booking.id,
+                onCancel: () => context.read<BookingsBloc>().add(
+                  CancelBookingRequested(booking),
+                ),
               );
             },
           ),
@@ -195,7 +227,15 @@ class _BookingsScreenState extends State<BookingsScreen>
 class _BookingCard extends StatefulWidget {
   final Booking booking;
   final bool isUpcoming;
-  const _BookingCard({required this.booking, this.isUpcoming = false});
+  final bool isProcessing;
+  final VoidCallback onCancel;
+
+  const _BookingCard({
+    required this.booking,
+    this.isUpcoming = false,
+    required this.isProcessing,
+    required this.onCancel,
+  });
 
   @override
   State<_BookingCard> createState() => _BookingCardState();
@@ -203,26 +243,6 @@ class _BookingCard extends StatefulWidget {
 
 class _BookingCardState extends State<_BookingCard> {
   final _reviewRepo = ReviewsRepository();
-
-  String _prettyDate(DateTime d) {
-    const months = [
-      'Jan',
-      'Feb',
-      'Mar',
-      'Apr',
-      'May',
-      'Jun',
-      'Jul',
-      'Aug',
-      'Sep',
-      'Oct',
-      'Nov',
-      'Dec',
-    ];
-    final m = months[d.month - 1];
-    return '$m ${d.day}, ${d.year}';
-  }
-  // Removed unused helper
 
   @override
   Widget build(BuildContext context) {
@@ -295,7 +315,6 @@ class _BookingCardState extends State<_BookingCard> {
               ),
             ],
           ),
-          // SizedBox(height: Dimension.height(12)),
           Row(
             children: [
               Image.asset(
@@ -344,9 +363,11 @@ class _BookingCardState extends State<_BookingCard> {
                 ],
               ),
               if (widget.isUpcoming) ...[
-                Spacer(),
+                const Spacer(),
                 ElevatedButton(
-                  onPressed: () => _showCancelDialog(context, widget.booking),
+                  onPressed: widget.isProcessing
+                      ? null
+                      : () => _showCancelDialog(context, widget.booking),
                   style: ButtonStyle(
                     backgroundColor: WidgetStateProperty.all(
                       context.read<ThemeNotifier>().isDark
@@ -366,63 +387,25 @@ class _BookingCardState extends State<_BookingCard> {
                       ),
                     ),
                   ),
-                  child: Text(
-                    'Cancel',
-                    style: TextStyle(
-                      fontSize: Dimension.font(14),
-                      color: Theme.of(context).colorScheme.onPrimary,
-                      fontWeight: FontWeight.w400,
-                    ),
-                  ),
+                  child: widget.isProcessing
+                      ? SizedBox(
+                          width: Dimension.width(16),
+                          height: Dimension.width(16),
+                          child: const CircularProgressIndicator(strokeWidth: 2),
+                        )
+                      : Text(
+                          'Cancel',
+                          style: TextStyle(
+                            fontSize: Dimension.font(14),
+                            color: Theme.of(context).colorScheme.onPrimary,
+                            fontWeight: FontWeight.w400,
+                          ),
+                        ),
                 ),
-                // SizedBox(width: Dimension.width(8)),
-                // ElevatedButton(
-                //   onPressed: () {
-                //     // Navigate to futsal details with groundId
-                //     Navigator.push(
-                //       context,
-                //       MaterialPageRoute(
-                //         builder: (context) => FutsalDetails(
-                //           futsalData: {
-                //             'id': booking.groundId,
-                //             'name': booking.groundName,
-                //           },
-                //         ),
-                //       ),
-                //     );
-                //   },
-                //   style: ButtonStyle(
-                //     backgroundColor: WidgetStateProperty.all(
-                //       Theme.of(context).colorScheme.primary,
-                //     ),
-                //     shadowColor: WidgetStateProperty.all(Colors.transparent),
-                //     padding: WidgetStateProperty.all(
-                //       EdgeInsets.symmetric(
-                //         horizontal: Dimension.width(12),
-                //         vertical: Dimension.height(0),
-                //       ),
-                //     ),
-                //     shape: WidgetStateProperty.all(
-                //       RoundedRectangleBorder(
-                //         borderRadius: BorderRadius.circular(Dimension.width(8)),
-                //       ),
-                //     ),
-                //   ),
-                //   child: Text(
-                //     'View Details',
-                //     style: TextStyle(
-                //       fontSize: Dimension.font(14),
-                //       color: Colors.white,
-                //       fontWeight: FontWeight.w400,
-                //     ),
-                //   ),
-                // ),
               ],
-              // Show review button for completed (status 3) or cancelled (status 2) bookings only
               if (!widget.isUpcoming &&
-                  (widget.booking.status == 3 ||
-                      widget.booking.status == 2)) ...[
-                Spacer(),
+                  (widget.booking.status == 3 || widget.booking.status == 2)) ...[
+                const Spacer(),
                 ElevatedButton(
                   onPressed: () => _showReviewDialog(context),
                   style: ButtonStyle(
@@ -524,20 +507,7 @@ class _BookingCardState extends State<_BookingCard> {
           ElevatedButton(
             onPressed: () {
               Navigator.of(dialogContext).pop();
-
-              // Show cancellation notification
-              NotificationService().showBookingCancelled(
-                groundName: booking.groundName,
-                bookingDate: _prettyDate(booking.bookingDate),
-              );
-
-              // TODO: Implement cancel booking logic
-              ScaffoldMessenger.of(context).showSnackBar(
-                SnackBar(
-                  content: Text('Booking cancelled'),
-                  duration: Duration(seconds: 2),
-                ),
-              );
+              widget.onCancel();
             },
             style: ElevatedButton.styleFrom(
               backgroundColor: Colors.red,
@@ -561,15 +531,28 @@ class _BookingCardState extends State<_BookingCard> {
   }
 }
 
-// Time formatting helper: accepts
-//  - 24h with seconds: HH:mm:ss (e.g. 13:00:00)
-//  - 24h without seconds: HH:mm (e.g. 13:00)
-//  - 12h with period: h:mm AM/PM (e.g. 1:00 PM)
-// Returns 12h format: HH:mm AM/PM (leading zero hour)
+String _prettyDate(DateTime d) {
+  const months = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+  ];
+  final m = months[d.month - 1];
+  return '$m ${d.day}, ${d.year}';
+}
+
 String _friendlyTime(String raw) {
   final trimmed = raw.trim();
 
-  // 24h with seconds
   final secMatch = RegExp(r'^(\d{2}):(\d{2}):(\d{2})$').firstMatch(trimmed);
   if (secMatch != null) {
     final h = int.parse(secMatch.group(1)!);
@@ -580,7 +563,6 @@ String _friendlyTime(String raw) {
     return '${h12.toString().padLeft(2, '0')}:$m $period';
   }
 
-  // 24h without seconds
   final noSecMatch = RegExp(r'^(\d{2}):(\d{2})$').firstMatch(trimmed);
   if (noSecMatch != null) {
     final h = int.parse(noSecMatch.group(1)!);
@@ -591,7 +573,6 @@ String _friendlyTime(String raw) {
     return '${h12.toString().padLeft(2, '0')}:$m $period';
   }
 
-  // 12h already (normalize hour padding & period case)
   final ampmMatch = RegExp(
     r'^(\d{1,2}):(\d{2})\s*(AM|PM)$',
     caseSensitive: false,
@@ -605,7 +586,7 @@ String _friendlyTime(String raw) {
     return '${h12.toString().padLeft(2, '0')}:$m $period';
   }
 
-  return trimmed; // fallback
+  return trimmed;
 }
 
 class _LoadingList extends StatelessWidget {
@@ -638,26 +619,19 @@ class _ErrorView extends StatelessWidget {
   final String message;
   final VoidCallback onRetry;
   const _ErrorView({required this.message, required this.onRetry});
+
   @override
   Widget build(BuildContext context) {
     return Center(
       child: Padding(
-        padding: EdgeInsets.all(Dimension.width(24)),
+        padding: EdgeInsets.symmetric(horizontal: Dimension.width(24)),
         child: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
-            Icon(
-              Icons.error_outline,
-              size: Dimension.width(48),
-              color: Colors.redAccent,
-            ),
+            Icon(Icons.error_outline, size: Dimension.width(32)),
+            SizedBox(height: Dimension.height(8)),
+            Text(message, textAlign: TextAlign.center),
             SizedBox(height: Dimension.height(12)),
-            Text(
-              message,
-              textAlign: TextAlign.center,
-              style: TextStyle(fontWeight: FontWeight.w600),
-            ),
-            SizedBox(height: Dimension.height(16)),
             ElevatedButton(onPressed: onRetry, child: const Text('Retry')),
           ],
         ),
@@ -670,48 +644,28 @@ class _EmptyView extends StatelessWidget {
   final int statusFilter;
   final VoidCallback onRefresh;
   const _EmptyView({required this.statusFilter, required this.onRefresh});
+
   @override
   Widget build(BuildContext context) {
-    String message;
-    if (statusFilter == 0) {
-      message = 'No upcoming bookings';
-    } else if (statusFilter == 1) {
-      message = 'No completed bookings';
-    } else {
-      message = 'No cancelled bookings';
-    }
+    final text = statusFilter == 0
+        ? 'No upcoming bookings.'
+        : statusFilter == 1
+        ? 'No completed bookings.'
+        : 'No cancelled bookings.';
 
-    return RefreshIndicator(
-      onRefresh: () async => onRefresh(),
-      child: ListView(
-        physics: const AlwaysScrollableScrollPhysics(),
-        children: [
-          SizedBox(height: Dimension.height(120)),
-          Icon(
-            Icons.event_busy,
-            size: Dimension.width(64),
-            color: Colors.grey[400],
-          ),
-          SizedBox(height: Dimension.height(16)),
-          Text(
-            message,
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: Dimension.font(16),
-              fontWeight: FontWeight.w700,
-            ),
-          ),
-          SizedBox(height: Dimension.height(8)),
-          Text(
-            'Pull to refresh or change tab',
-            textAlign: TextAlign.center,
-            style: TextStyle(
-              fontSize: Dimension.font(12),
-              color: Colors.grey[600],
-              fontWeight: FontWeight.w500,
-            ),
-          ),
-        ],
+    return Center(
+      child: Padding(
+        padding: EdgeInsets.symmetric(horizontal: Dimension.width(24)),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Icon(Icons.calendar_today_outlined, size: Dimension.width(32)),
+            SizedBox(height: Dimension.height(8)),
+            Text(text, textAlign: TextAlign.center),
+            SizedBox(height: Dimension.height(12)),
+            ElevatedButton(onPressed: onRefresh, child: const Text('Refresh')),
+          ],
+        ),
       ),
     );
   }

--- a/futsal_app/lib/view/bookings/data/repository/booking_repository.dart
+++ b/futsal_app/lib/view/bookings/data/repository/booking_repository.dart
@@ -6,35 +6,51 @@ import '../model/booking.dart';
 class BookingRepository {
   final ApiService _api = ApiService();
 
-  Future<List<Booking>> getBookings() async {
+  Future<List<Booking>> getBookings({String? path}) async {
     try {
-      final res = await _api.get(ApiConst.bookings);
+      final res = await _api.get(path ?? ApiConst.bookings);
       if (res.statusCode == 200) {
-        final data = res.data;
-        if (data is List) {
-          return data
-              .map((e) => Booking.fromJson(e as Map<String, dynamic>))
-              .toList();
-        } else if (data is Map && data['items'] is List) {
-          return (data['items'] as List)
-              .map((e) => Booking.fromJson(e as Map<String, dynamic>))
-              .toList();
-        } else {
-          return [];
-        }
-      } else {
-        throw Exception('Failed to load bookings: ${res.statusCode}');
+        return _parseBookingsResponse(res.data);
       }
-    } on DioException catch (e) {
-      if (e.response != null) {
-        throw Exception(
-          e.response?.data['message'] ?? 'Failed to load bookings',
-        );
-      } else {
-        throw Exception('Network error: ${e.message}');
-      }
+      throw Exception('Failed to load bookings: ${res.statusCode}');
     } catch (e) {
-      throw Exception('Unexpected error: $e');
+      throw _mapException(e, fallback: 'Failed to load bookings.');
+    }
+  }
+
+  Future<List<Booking>> getPendingBookings() {
+    return getBookings(path: ApiConst.pendingBookings);
+  }
+
+  Future<List<Booking>> getCompletedBookings() {
+    return getBookings(path: ApiConst.completedBookings);
+  }
+
+  Future<List<Booking>> getCancelledBookings() {
+    return getBookings(path: ApiConst.cancelledBookings);
+  }
+
+  Future<void> cancelBooking(int bookingId) async {
+    try {
+      final res = await _api.patch(ApiConst.cancelBooking(bookingId));
+      if (res.statusCode == 200 || res.statusCode == 204) {
+        return;
+      }
+      throw Exception('Failed to cancel booking.');
+    } catch (e) {
+      throw _mapException(e, fallback: 'Unable to cancel booking right now.');
+    }
+  }
+
+  Future<void> acceptBooking(int bookingId) async {
+    try {
+      final res = await _api.patch(ApiConst.acceptBooking(bookingId));
+      if (res.statusCode == 200 || res.statusCode == 204) {
+        return;
+      }
+      throw Exception('Failed to accept booking.');
+    } catch (e) {
+      throw _mapException(e, fallback: 'Unable to accept booking right now.');
     }
   }
 
@@ -58,21 +74,73 @@ class BookingRepository {
       final res = await _api.post(ApiConst.bookings, data: bookingData);
 
       if (res.statusCode == 200 || res.statusCode == 201) {
-        // Booking successful - response format may vary
         return;
-      } else {
-        throw Exception('Failed to create booking: ${res.statusCode}');
       }
-    } on DioException catch (e) {
-      if (e.response != null) {
-        throw Exception(
-          e.response?.data['message'] ?? 'Failed to create booking',
-        );
-      } else {
-        throw Exception('Network error: ${e.message}');
-      }
+      throw Exception('Failed to create booking: ${res.statusCode}');
     } catch (e) {
-      throw Exception('Unexpected error: $e');
+      throw _mapException(e, fallback: 'Unable to create booking right now.');
     }
   }
+
+  List<Booking> _parseBookingsResponse(dynamic data) {
+    if (data is List) {
+      return data.map((e) => Booking.fromJson(e as Map<String, dynamic>)).toList();
+    }
+
+    if (data is Map && data['items'] is List) {
+      return (data['items'] as List)
+          .map((e) => Booking.fromJson(e as Map<String, dynamic>))
+          .toList();
+    }
+
+    return [];
+  }
+
+  Exception _mapException(Object error, {required String fallback}) {
+    if (error is ApiException) {
+      return BookingRepositoryException(
+        message: _friendlyStatusMessage(error.statusCode, fallback),
+        statusCode: error.statusCode,
+      );
+    }
+
+    if (error is DioException) {
+      final statusCode = error.response?.statusCode;
+      return BookingRepositoryException(
+        message: _friendlyStatusMessage(statusCode, fallback),
+        statusCode: statusCode,
+      );
+    }
+
+    if (error is BookingRepositoryException) {
+      return error;
+    }
+
+    return BookingRepositoryException(message: fallback);
+  }
+
+  String _friendlyStatusMessage(int? statusCode, String fallback) {
+    switch (statusCode) {
+      case 400:
+        return 'Invalid booking request. Please review details and try again.';
+      case 401:
+        return 'Your session has expired. Please login again.';
+      case 403:
+        return 'You do not have permission to perform this action.';
+      case 404:
+        return 'Booking not found. It may have already been updated.';
+      default:
+        return fallback;
+    }
+  }
+}
+
+class BookingRepositoryException implements Exception {
+  final String message;
+  final int? statusCode;
+
+  BookingRepositoryException({required this.message, this.statusCode});
+
+  @override
+  String toString() => message;
 }


### PR DESCRIPTION
### Motivation
- Provide server-backed cancel/accept actions and filtered booking lists so the app can perform booking lifecycle changes reliably and show deterministic UI feedback.
- Surface explicit, user-friendly messages for common API error responses (400/401/403/404) so users see actionable information when operations fail.

### Description
- Added booking endpoint constants in `ApiConst` for `Booking/cancel/{id}`, `Booking/accept/{id}` and list filters `Booking/pending`, `Booking/completed`, `Booking/cancelled` (file: `lib/core/service/api_const.dart`).
- Extended `BookingRepository` with `cancelBooking(int)`, `acceptBooking(int)` and optional filtered fetch helpers `getPendingBookings()`, `getCompletedBookings()`, `getCancelledBookings()` that call `ApiService.patch(...)` and `ApiService.get(...)` respectively, and added response parsing helpers and a `_mapException` flow that maps HTTP status codes to friendly messages (file: `lib/view/bookings/data/repository/booking_repository.dart`).
- Introduced a bookings BLoC with events `LoadBookings`, `CancelBookingRequested`, `AcceptBookingRequested` and a `BookingsState` that tracks loading, `processingBookingId`, last action type and action booking so UI updates are deterministic after server confirmation (files: `lib/view/bookings/bloc/*.dart`).
- Refactored `BookingsScreen` to use the BLoC for loading and actions; wired the cancel button to dispatch `CancelBookingRequested`, show a progress state while the request is in-flight, refresh the booking list after success, and show user-facing snackbars and the cancellation notification only after server confirmation (file: `lib/view/bookings/bookings.dart`).

### Testing
- Ran `git diff --check` to ensure no obvious whitespace/diff errors and found no issues. (success)
- Attempted formatter/tooling check with `dart format ...` but the `dart` CLI is not available in the environment, so formatting could not be verified here. (skipped)
- Attempted to query `flutter --version` to verify Flutter tooling, but the `flutter` CLI is not available in the environment. (skipped)
- No new automated unit tests were added in this change; runtime verification should be performed in a Flutter-enabled environment to run formatters and execute the app flows.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76a24f57c8330b343f9a4f8516e37)