### PR TITLE
Use authenticated principal for booking user assignment

### DIFF
--- a/FutsalApi/FutsalApi.ApiService/Routes/Booking.cs
+++ b/FutsalApi/FutsalApi.ApiService/Routes/Booking.cs
@@ -268,10 +268,17 @@ public class BookingApiEndpoints : IEndpoint
         [FromServices] IBookingRepository repository,
         [FromServices] IGroundClosureRepository groundClosureRepository,
         [FromServices] IFutsalGroundRepository groundRepository,
+        ClaimsPrincipal claimsPrincipal,
+        [FromServices] UserManager<User> userManager,
         [FromBody] BookingRequest bookingRequest)
     {
         try
         {
+            if (await userManager.GetUserAsync(claimsPrincipal) is not { } user)
+            {
+                return TypedResults.Problem("User not found.", statusCode: StatusCodes.Status404NotFound);
+            }
+
             if (await groundClosureRepository.IsGroundClosedAsync(bookingRequest.GroundId, bookingRequest.BookingDate, bookingRequest.StartTime, bookingRequest.EndTime))
             {
                 return TypedResults.Problem("The selected time slot is closed for booking.", statusCode: StatusCodes.Status400BadRequest);
@@ -295,7 +302,7 @@ public class BookingApiEndpoints : IEndpoint
 
             Booking booking = new Booking
             {
-                UserId = bookingRequest.UserId,
+                UserId = user.Id,
                 GroundId = bookingRequest.GroundId,
                 BookingDate = bookingRequest.BookingDate,
                 StartTime = bookingRequest.StartTime,

--- a/FutsalApi/FutsalApi.ApiService/Validators/BookingRequestValidator.cs
+++ b/FutsalApi/FutsalApi.ApiService/Validators/BookingRequestValidator.cs
@@ -10,7 +10,6 @@ public class BookingRequestValidator : AbstractValidator<BookingRequest>
 {
     public BookingRequestValidator()
     {
-        RuleFor(x => x.UserId).NotEmpty().WithMessage("User ID is required");
         RuleFor(x => x.GroundId).NotEmpty().WithMessage("Ground ID is required");
         RuleFor(x => x.BookingDate).GreaterThanOrEqualTo(DateTime.UtcNow.Date)
             .WithMessage("Booking date cannot be in the past");

--- a/FutsalApi/FutsalApi.Data/Models/BookingRequest.cs
+++ b/FutsalApi/FutsalApi.Data/Models/BookingRequest.cs
@@ -4,7 +4,6 @@ namespace FutsalApi.Data.Models;
 
 public class BookingRequest
 {
-    public required string UserId { get; set; }
     public int GroundId { get; set; }
     public DateTime BookingDate { get; set; }
     public TimeSpan StartTime { get; set; }

--- a/FutsalApi/FutsalApi.Tests/BookingApiEndpointsTests.cs
+++ b/FutsalApi/FutsalApi.Tests/BookingApiEndpointsTests.cs
@@ -1,7 +1,6 @@
 ﻿using System.Linq.Expressions;
 using System.Security.Claims;
 using FutsalApi.Data.Models;
-using FutsalApi.ApiService.Repositories;
 using FutsalApi.ApiService.Routes;
 using Microsoft.AspNetCore.Http.HttpResults;
 using Microsoft.AspNetCore.Identity;
@@ -9,7 +8,6 @@ using Moq;
 using FluentAssertions;
 using FutsalApi.ApiService.Repositories.Interfaces;
 using FutsalApi.Data.DTO;
-using FutsalApi.Data.Models;
 
 namespace FutsalApi.Tests;
 
@@ -107,10 +105,13 @@ public class BookingApiEndpointsTests
     public async Task CreateBooking_ReturnsOk_WhenBookingIsCreated()
     {
         // Arrange
+        var user = new User { Id = "user1" };
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(ClaimTypes.NameIdentifier, user.Id) }));
+        _userManagerMock.Setup(um => um.GetUserAsync(claimsPrincipal)).ReturnsAsync(user);
+
         var now = DateTime.UtcNow.TimeOfDay;
         var bookingRequest = new BookingRequest
         {
-            UserId = "user1",
             GroundId = 1,
             BookingDate = DateTime.Today,
             StartTime = now.Add(TimeSpan.FromHours(1)),
@@ -153,6 +154,8 @@ public class BookingApiEndpointsTests
             _bookingRepositoryMock.Object,
             _groundClosureRepositoryMock.Object,
             _groundRepositoryMock.Object,
+            claimsPrincipal,
+            _userManagerMock.Object,
             bookingRequest);
 
         // Assert
@@ -167,9 +170,12 @@ public class BookingApiEndpointsTests
     public async Task CreateBooking_ReturnsProblem_WhenGroundNotFound()
     {
         // Arrange
+        var user = new User { Id = "user1" };
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(ClaimTypes.NameIdentifier, user.Id) }));
+        _userManagerMock.Setup(um => um.GetUserAsync(claimsPrincipal)).ReturnsAsync(user);
+
         var bookingRequest = new BookingRequest
         {
-            UserId = "user1",
             GroundId = 1,
             BookingDate = DateTime.Today,
             StartTime = TimeSpan.FromHours(10),
@@ -189,6 +195,8 @@ public class BookingApiEndpointsTests
             _bookingRepositoryMock.Object,
             _groundClosureRepositoryMock.Object,
             _groundRepositoryMock.Object,
+            claimsPrincipal,
+            _userManagerMock.Object,
             bookingRequest);
 
         // Assert
@@ -203,9 +211,12 @@ public class BookingApiEndpointsTests
     public async Task CreateBooking_ReturnsProblem_WhenSlotClosed()
     {
         // Arrange
+        var user = new User { Id = "user1" };
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(ClaimTypes.NameIdentifier, user.Id) }));
+        _userManagerMock.Setup(um => um.GetUserAsync(claimsPrincipal)).ReturnsAsync(user);
+
         var bookingRequest = new BookingRequest
         {
-            UserId = "user1",
             GroundId = 1,
             BookingDate = DateTime.Today,
             StartTime = TimeSpan.FromHours(10),
@@ -221,6 +232,8 @@ public class BookingApiEndpointsTests
             _bookingRepositoryMock.Object,
             _groundClosureRepositoryMock.Object,
             _groundRepositoryMock.Object,
+            claimsPrincipal,
+            _userManagerMock.Object,
             bookingRequest);
 
         // Assert
@@ -235,10 +248,12 @@ public class BookingApiEndpointsTests
     public async Task CreateBooking_ThrowsException_WhenCalledWithoutBookingRequest()
     {
         // Arrange
-        // All dependencies are mocked, but bookingRequest is missing on purpose to test compile error fix
+        var user = new User { Id = "user1" };
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(ClaimTypes.NameIdentifier, user.Id) }));
+        _userManagerMock.Setup(um => um.GetUserAsync(claimsPrincipal)).ReturnsAsync(user);
+
         var bookingRequest = new BookingRequest
         {
-            UserId = "user1",
             GroundId = 1,
             BookingDate = DateTime.Today,
             StartTime = TimeSpan.FromHours(10),
@@ -247,8 +262,95 @@ public class BookingApiEndpointsTests
 
         // Act & Assert
         // This test is just to ensure the method is always called with bookingRequest
-        var result = await _endpoints.CreateBooking(_bookingRepositoryMock.Object, _groundClosureRepositoryMock.Object, _groundRepositoryMock.Object, bookingRequest);
+        var result = await _endpoints.CreateBooking(_bookingRepositoryMock.Object, _groundClosureRepositoryMock.Object, _groundRepositoryMock.Object, claimsPrincipal, _userManagerMock.Object, bookingRequest);
         result.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task CreateBooking_UsesAuthenticatedUserId_IgnoresPayloadUserId()
+    {
+        // Arrange
+        var user = new User { Id = "auth-user" };
+        var claimsPrincipal = new ClaimsPrincipal(new ClaimsIdentity(new Claim[] { new Claim(ClaimTypes.NameIdentifier, user.Id) }));
+        _userManagerMock.Setup(um => um.GetUserAsync(claimsPrincipal)).ReturnsAsync(user);
+
+        var now = DateTime.UtcNow.TimeOfDay;
+        var bookingRequest = new BookingRequest
+        {
+            GroundId = 1,
+            BookingDate = DateTime.Today,
+            StartTime = now.Add(TimeSpan.FromHours(1)),
+            EndTime = now.Add(TimeSpan.FromHours(2))
+        };
+
+        var ground = new FutsalGroundResponse
+        {
+            Id = 1,
+            Name = "Ground 1",
+            Location = "Location 1",
+            OwnerId = "Owner1",
+            PricePerHour = 200,
+            OpenTime = now.Subtract(TimeSpan.FromHours(2)),
+            CloseTime = now.Add(TimeSpan.FromHours(6)),
+        };
+
+        _groundClosureRepositoryMock
+            .Setup(r => r.IsGroundClosedAsync(bookingRequest.GroundId, bookingRequest.BookingDate, bookingRequest.StartTime, bookingRequest.EndTime))
+            .ReturnsAsync(false);
+
+        _groundRepositoryMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Expression<Func<FutsalGround, bool>>>() ))
+            .ReturnsAsync(ground);
+
+        Booking? capturedBooking = null;
+        _bookingRepositoryMock
+            .Setup(r => r.CreateBookingAsync(It.IsAny<Booking>()))
+            .Callback<Booking>(b => capturedBooking = b)
+            .ReturnsAsync(1);
+
+        // Act
+        var result = await _endpoints.CreateBooking(
+            _bookingRepositoryMock.Object,
+            _groundClosureRepositoryMock.Object,
+            _groundRepositoryMock.Object,
+            claimsPrincipal,
+            _userManagerMock.Object,
+            bookingRequest);
+
+        // Assert
+        result.Result.Should().BeOfType<Ok<string>>();
+        capturedBooking.Should().NotBeNull();
+        capturedBooking!.UserId.Should().Be("auth-user");
+    }
+
+    [Fact]
+    public async Task CreateBooking_ReturnsProblem_WhenAuthenticatedUserNotFound()
+    {
+        // Arrange
+        var claimsPrincipal = new ClaimsPrincipal();
+        _userManagerMock.Setup(um => um.GetUserAsync(claimsPrincipal)).ReturnsAsync((User?)null);
+
+        var bookingRequest = new BookingRequest
+        {
+            GroundId = 1,
+            BookingDate = DateTime.Today,
+            StartTime = TimeSpan.FromHours(10),
+            EndTime = TimeSpan.FromHours(12)
+        };
+
+        // Act
+        var result = await _endpoints.CreateBooking(
+            _bookingRepositoryMock.Object,
+            _groundClosureRepositoryMock.Object,
+            _groundRepositoryMock.Object,
+            claimsPrincipal,
+            _userManagerMock.Object,
+            bookingRequest);
+
+        // Assert
+        result.Result.Should().BeOfType<ProblemHttpResult>();
+        var problem = result.Result as ProblemHttpResult;
+        problem!.StatusCode.Should().Be(StatusCodes.Status404NotFound);
     }
 
     [Fact]
@@ -257,7 +359,6 @@ public class BookingApiEndpointsTests
         // Arrange
         var bookingRequest = new BookingRequest
         {
-            UserId = "user1",
             GroundId = 1,
             BookingDate = DateTime.Today,
             StartTime = TimeSpan.FromHours(10),
@@ -288,7 +389,6 @@ public class BookingApiEndpointsTests
         // Arrange
         var bookingRequest = new BookingRequest
         {
-            UserId = "user1",
             GroundId = 1,
             BookingDate = DateTime.Today,
             StartTime = TimeSpan.FromHours(10),
@@ -312,7 +412,6 @@ public class BookingApiEndpointsTests
         // Arrange
         var bookingRequest = new BookingRequest
         {
-            UserId = "user1",
             GroundId = 1,
             BookingDate = DateTime.Today,
             StartTime = TimeSpan.FromHours(10),

--- a/FutsalApi/FutsalApi.UI/FutsalApi.UI.Shared/User/BookingForm.razor
+++ b/FutsalApi/FutsalApi.UI/FutsalApi.UI.Shared/User/BookingForm.razor
@@ -30,32 +30,16 @@
     <button type="submit" class="btn btn-primary">Submit</button>
 </EditForm>
 
-@using System.Security.Claims
-@using Microsoft.AspNetCore.Components.Authorization
 @code {
     [Parameter]
     public int GroundId { get; set; }
 
-    private BookingRequest bookingRequest = new() { UserId = "" };
+    private BookingRequest bookingRequest = new();
 
-    [CascadingParameter]
-    private Task<AuthenticationState>? authenticationStateTask { get; set; }
-
-    protected override async Task OnInitializedAsync()
+    protected override Task OnInitializedAsync()
     {
         bookingRequest.GroundId = GroundId;
-
-        if (authenticationStateTask != null)
-        {
-            var authState = await authenticationStateTask;
-            var user = authState?.User;
-
-            if (user?.Identity?.IsAuthenticated == true)
-            {
-                // Assuming UserId is a string and can be parsed from a claim
-                bookingRequest.UserId = user.FindFirst(ClaimTypes.NameIdentifier)?.Value ?? "";
-            }
-        }
+        return Task.CompletedTask;
     }
 
     private async Task HandleValidSubmit()

--- a/futsal_app/lib/view/book_now/book_now.dart
+++ b/futsal_app/lib/view/book_now/book_now.dart
@@ -123,7 +123,6 @@ class _BookNowState extends State<BookNow> {
         throw Exception('User profile not loaded');
       }
 
-      final userId = profileState.userInfo.id;
       final groundId = widget.futsalData['_id'] ?? widget.futsalData['id'];
       final selectedDate = _generateNext7Days()[_selectedDateIndex];
 
@@ -138,7 +137,6 @@ class _BookNowState extends State<BookNow> {
       final endTime = _convertTo24HourFormat(times[1]);
 
       await _bookingRepo.createBooking(
-        userId: userId,
         groundId: groundId is int
             ? groundId
             : int.tryParse(groundId.toString()) ?? 0,

--- a/futsal_app/lib/view/bookings/data/repository/booking_repository.dart
+++ b/futsal_app/lib/view/bookings/data/repository/booking_repository.dart
@@ -40,7 +40,6 @@ class BookingRepository {
 
   /// Create a new booking
   Future<void> createBooking({
-    required String userId,
     required int groundId,
     required DateTime bookingDate,
     required String startTime,
@@ -48,7 +47,6 @@ class BookingRepository {
   }) async {
     try {
       final bookingData = {
-        'userId': userId,
         'groundId': groundId,
         'bookingDate': bookingDate.toIso8601String(),
         'startTime': startTime,


### PR DESCRIPTION
### Motivation
- Prevent clients from specifying `UserId` in booking payloads so a user cannot create bookings on behalf of another account.
- Ensure booking ownership is always taken from the authenticated principal on the server side for stronger security and simpler client models.

### Description
- Removed the `UserId` property from `BookingRequest` and removed server-side validation that required it (`FutsalApi.Data.Models.BookingRequest`, `BookingRequestValidator`).
- Updated `BookingApiEndpoints.CreateBooking` to accept `ClaimsPrincipal` and `UserManager<User>`, resolve the authenticated user, return `404` when the user cannot be resolved, and set `booking.UserId = user.Id` before creating the booking (`FutsalApi.ApiService.Routes.Booking`).
- Updated client flows to stop sending `userId`: Blazor UI `BookingForm.razor` now submits only booking fields and the Flutter code removed `userId` from the repository method signature and request body (`FutsalApi.UI.FutsalApi.UI.Shared/User/BookingForm.razor`, `futsal_app/lib/view/book_now/book_now.dart`, `futsal_app/lib/view/bookings/data/repository/booking_repository.dart`).
- Added/updated tests in `FutsalApi.Tests/BookingApiEndpointsTests.cs` to provide a `ClaimsPrincipal` + `UserManager<User>` to `CreateBooking`, to assert the repository receives a `Booking` with `UserId` set to the authenticated user, and to cover the authenticated-user-not-found path.

### Testing
- Updated unit tests in `FutsalApi.Tests` to exercise the new `CreateBooking` behavior and added a regression test `CreateBooking_UsesAuthenticatedUserId_IgnoresPayloadUserId`; these tests were added to the codebase but not executed in this environment.
- Attempted to run `dotnet test FutsalApi/FutsalApi.Tests/FutsalApi.Tests.csproj` but the `dotnet` SDK is not available in the execution environment, so automated tests could not be run here (command failed with `dotnet: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b76a295a6483308fba95944cacc9b3)